### PR TITLE
feat(pad): add preview of PadButtons codes

### DIFF
--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -22,7 +22,7 @@ class Pad extends React.Component<PadProps, PadState> {
 			const cells = [];
 			for (let j = 0; j < this.props.columns; j++) {
 				const k = defaultKeyCodes[i][j];
-				cells.push(<PadButton code={k} key={k} active={this.state.pressed.includes(k)} />);
+				cells.push(<PadButton code={k} key={k} active={this.state.pressed.includes(k)} alt={this.state.pressed.includes('AltRight')} />);
 			}
 			rows.push(<div className='pad-button-row'>{cells}</div>);
 		}

--- a/src/components/PadButton.tsx
+++ b/src/components/PadButton.tsx
@@ -14,9 +14,14 @@ class PadButton extends React.Component<PadButtonProps> {
 		const style = {
 			backgroundColor: this.props.colors[this.props.active ? 'active' : 'resting']
 		};
+		let label;
+		if (this.props.label)
+			label = this.props.label;
+		if (this.props.alt)
+			label = this.props.code;
 		return (
 			<div className='pad-button' style={style}>
-				{this.props.label && <div className='pad-button-label'>{this.props.label}</div>}
+				{<div className='pad-button-label'>{label}</div>}
 			</div>
 		);
 	}

--- a/src/style/PadButton.sass
+++ b/src/style/PadButton.sass
@@ -8,5 +8,5 @@
 	justify-content: center
 	align-items: center
 	.pad-button-label
-		font: 8pt monospace
+		font: 10pt monospace
 		

--- a/src/style/PadButton.sass
+++ b/src/style/PadButton.sass
@@ -9,4 +9,4 @@
 	align-items: center
 	.pad-button-label
 		font: 8pt monospace
-		text-transform: uppercase;
+		

--- a/src/types/PadButtonProps.ts
+++ b/src/types/PadButtonProps.ts
@@ -7,6 +7,10 @@ interface PadButtonProps {
 	 */
 	active: boolean;
 	/**
+	 * Whether the AltRight key is pressed, which displays the code of the PadButton.
+	 */
+	alt: boolean;
+	/**
 	 * Color properties of the PadButton.
 	 */
 	colors: {


### PR DESCRIPTION
**Changes of this PR**
Pressing the `AltRight` key will preview the code of every PadButtons, this value taking the place of its label.