### PR TITLE
refactor(pad): clean ButtonProperties

### DIFF
--- a/src/components/ButtonConfigurator.tsx
+++ b/src/components/ButtonConfigurator.tsx
@@ -21,7 +21,7 @@ class ButtonConfigurator extends React.Component<ButtonConfiguratorProps> {
 		this.#refs = {
 			activeColor: React.createRef<HTMLInputElement>(),
 			label: React.createRef<HTMLInputElement>(),
-			restingColor: React.createRef<HTMLInputElement>()
+			idleColor: React.createRef<HTMLInputElement>()
 		};
 		this.listening = {
 			activeColor: false,
@@ -68,9 +68,9 @@ class ButtonConfigurator extends React.Component<ButtonConfiguratorProps> {
 		) {
 			// Should find a way to automate this value updates instead of manually updating each of them.
 			if (this.#refs.activeColor.current)
-				this.#refs.activeColor.current.value = this.props.button.colors.active;
-			if (this.#refs.restingColor.current)
-				this.#refs.restingColor.current.value = this.props.button.colors.resting;
+				this.#refs.activeColor.current.value = this.props.button.activeColor;
+			if (this.#refs.idleColor.current)
+				this.#refs.idleColor.current.value = this.props.button.idleColor;
 			if (this.#refs.label.current)
 				this.#refs.label.current.value = this.props.button.label;
 			this.lastSelectedPos = this.props.button.position;
@@ -93,10 +93,10 @@ class ButtonConfigurator extends React.Component<ButtonConfiguratorProps> {
 				</div>
 				<div className='button-configurator-subtitle'>Colors</div>
 				<div className='button-configurator-row'>
-					<input type='color' ref={this.#refs.activeColor} name='colors.active' />
-					<label htmlFor='colors.active'>Active  color</label>
-					<input type='color' ref={this.#refs.restingColor} name='colors.resting' />
-					<label htmlFor='colors.resting'>Resting color</label>
+					<input type='color' ref={this.#refs.activeColor} name='activeColor' />
+					<label htmlFor='activeColor'>Active color</label>
+					<input type='color' ref={this.#refs.idleColor} name='idleColor' />
+					<label htmlFor='idleColor'>Idle color</label>
 				</div>
 				<div className='button-configurator-subtitle'>Label</div>
 				<input type='text' ref={this.#refs.label} name='label' />

--- a/src/components/ButtonConfigurator.tsx
+++ b/src/components/ButtonConfigurator.tsx
@@ -93,9 +93,9 @@ class ButtonConfigurator extends React.Component<ButtonConfiguratorProps> {
 				</div>
 				<div className='button-configurator-subtitle'>Colors</div>
 				<div className='button-configurator-row'>
-					<input type='color' defaultValue={this.props.button.colors.active} ref={this.#refs.activeColor} name='colors.active' />
+					<input type='color' ref={this.#refs.activeColor} name='colors.active' />
 					<label htmlFor='colors.active'>Active  color</label>
-					<input type='color' defaultValue={this.props.button.colors.resting} ref={this.#refs.restingColor} name='colors.resting' />
+					<input type='color' ref={this.#refs.restingColor} name='colors.resting' />
 					<label htmlFor='colors.resting'>Resting color</label>
 				</div>
 				<div className='button-configurator-subtitle'>Label</div>

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -62,11 +62,9 @@ class Pad extends React.Component<PadProps, PadState> {
 			buttons.push([]);
 			for (let j = 0; j < 4; j++) {
 				const btn = {
-					colors: {
-						active: '#fffc33',
-						flat: false,
-						resting: '#aaaaaa'
-					},
+					activeColor: '#fffc33',
+					flatColors: false,
+					idleColor: '#aaaaaa',
 					label: '',
 					code: defaultKeyCodes[i][j],
 					position: [i, j]

--- a/src/components/PadButton.tsx
+++ b/src/components/PadButton.tsx
@@ -16,7 +16,7 @@ class PadButton extends React.Component<PadButtonProps> {
 
 	render(): React.ReactNode {
 		const style = {
-			backgroundColor: this.props.colors[this.props.active ? 'active' : 'resting']
+			backgroundColor: this.props.active ? this.props.activeColor : this.props.idleColor
 		};
 		let label;
 		if (this.props.label)
@@ -36,11 +36,9 @@ class PadButton extends React.Component<PadButtonProps> {
 	}
 
 	static defaultProps = {
-		colors: {
-			active: '#fffc33',
-			flat: false,
-			resting: '#aaaaaa'
-		}
+		activeColor: '#fffc33',
+		flatColors: false,
+		idleColor: '#aaaaaa'
 	};
 }
 

--- a/src/types/ButtonProperties.ts
+++ b/src/types/ButtonProperties.ts
@@ -3,26 +3,21 @@
  */
 interface ButtonProperties {
 	/**
+	 * The color to display when the button component is active.
+	 */
+	activeColor: string;
+	/**
 	 * The code of the key that triggers this button.
 	 */
 	code: string;
 	/**
-	 * Color properties of the button component.
+	 * When set to true, the button's colors will not have a slight radial gradient effect.
 	 */
-	colors: {
-		/**
-		 * The color to display when the button component is active.
-		 */
-		active: string;
-		/**
-		 * When set to true, the colors will not have a slight radial gradient effect to smooth it.
-		 */
-		flat: boolean;
-		/**
-		 * The color to display when the button component is not active.
-		 */
-		resting: string;
-	};
+	flatColors: boolean;
+	/**
+	 * The color to display when the button component is not active.
+	 */
+	idleColor: string;
 	/**
 	 * A text to display on the button component.
 	 */


### PR DESCRIPTION
**Changes of this PR**
This PR removes any nested ButtonProperties (eg. `colors`) to facilitate updating them. It also gives more meaningful names (eg. `restingColor` -> `idleColor`).