### PR TITLE
feat(Pad): improve indicators

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Added an indicator of the progress of the playing sound of each button.
+ - Added the ability to stop a playing audio simply by pressing the button again.
 ### Changed
  - The active color now stays on display as long as the button's audio is being played, it no longer depends on the user's keypress.
+ - An active button now blinks in its active color instead of staticly displaying it.
+ - A button now can't play its sound simultaneously. It must wait for one instance of the sound to stop before playing a new one.
 ## [0.1.0-canary.2] - 2021-08-14
 ### Changed
  - Changed action when clicking a button. It will now select it in the configurator instead of triggering its sound.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - The active color now stays on display as long as the button's audio is being played, it no longer depends on the user's keypress.
 ## [0.1.0-canary.2] - 2021-08-14
 ### Changed
  - Changed action when clicking a button. It will now select it in the configurator instead of triggering its sound.

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -32,8 +32,10 @@ export default class AudioManager extends AudioContext {
 	/**
 	 * Plays a sound.
 	 * @param name The name of the sound to play.
+	 * @param volume The volume to play the sound with.
+	 * @param end The function to call when the sound ends.
 	 */
-	playSound(name: string, volume: number): void {
+	playSound(name: string, volume: number, end: () => void): void {
 		if (!this.sounds.has(name))
 			return;
 		// Type assertion required because we know that it is defined with the check, but TypeScript can't understand it.
@@ -45,5 +47,6 @@ export default class AudioManager extends AudioContext {
 		source.connect(gain);
 		gain.connect(this.destination);
 		source.start();
+		source.addEventListener('ended', end);
 	}
 }

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -6,10 +6,15 @@ export default class AudioManager extends AudioContext {
 	 * The sounds loaded in the manager, mapped by their paths.
 	 */
 	sounds: Map<string, AudioBuffer>;
+	/**
+	 * The currently playing sources, mapped by their paths.
+	 */
+	playing: Map<string, AudioBufferSourceNode>;
 
 	constructor() {
 		super();
 		this.sounds = new Map();
+		this.playing = new Map();
 	}
 
 	/**
@@ -47,6 +52,10 @@ export default class AudioManager extends AudioContext {
 		source.connect(gain);
 		gain.connect(this.destination);
 		source.start();
-		source.addEventListener('ended', end);
+		this.playing.set(name, source);
+		source.addEventListener('ended', () => {
+			this.playing.delete(name);
+			end();
+		});
 	}
 }

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -65,7 +65,7 @@ class Pad extends React.Component<PadProps, PadState> {
 	addPressed(key: string): void {
 		this.setState({ pressedButtons: [...this.state.pressedButtons, key] });
 		const btn = this.state.buttonProperties.flat().find(b => b.code === key);
-		if (!btn || !btn.audio || !this.audio.sounds.has(btn.audio))
+		if (!btn || !btn.audio || btn.active || !this.audio.sounds.has(btn.audio))
 			return;
 		this.updateButtonProperties(btn.position, { active: true });
 		this.audio.playSound(btn.audio, btn.volume, () => this.updateButtonProperties(btn.position, { active: false }));

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -22,6 +22,12 @@ class Pad extends React.Component<PadProps, PadState> {
 		if (stored) {
 			try {
 				properties = JSON.parse(stored);
+				// This property depends on the runtime. If the app is closed, it must be reset.
+				for (const row of properties) {
+					for (const obj of row) {
+						obj.active = false;
+					}
+				}
 				properties.flat().forEach(props => {
 					if (!props.audio)
 						return;
@@ -61,7 +67,8 @@ class Pad extends React.Component<PadProps, PadState> {
 		const btn = this.state.buttonProperties.flat().find(b => b.code === key);
 		if (!btn || !btn.audio || !this.audio.sounds.has(btn.audio))
 			return;
-		this.audio.playSound(btn.audio, btn.volume);
+		this.updateButtonProperties(btn.position, { active: true });
+		this.audio.playSound(btn.audio, btn.volume, () => this.updateButtonProperties(btn.position, { active: false }));
 	}
 
 	/**

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -109,6 +109,7 @@ class Pad extends React.Component<PadProps, PadState> {
 			for (let j = 0; j < 4; j++) {
 				const plus = j < 2 ? 0 : 1;
 				const btn = {
+					active: false,
 					activeColor: '#fffc33',
 					flatColors: false,
 					idleColor: colors[color + plus],
@@ -131,7 +132,6 @@ class Pad extends React.Component<PadProps, PadState> {
 				const btn = this.state.buttonProperties[i][j];
 				const props: PadButtonProps = {
 					...btn,
-					active: this.state.pressedButtons.includes(btn.code),
 					alt: this.state.pressedButtons.includes('AltRight'),
 					select: (coos: number[]) => this.selectButton(coos)
 				};

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -139,6 +139,7 @@ class Pad extends React.Component<PadProps, PadState> {
 				const btn = this.state.buttonProperties[i][j];
 				const props: PadButtonProps = {
 					...btn,
+					audioManager: this.audio,
 					alt: this.state.pressedButtons.includes('AltRight'),
 					select: (coos: number[]) => this.selectButton(coos)
 				};

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -65,8 +65,11 @@ class Pad extends React.Component<PadProps, PadState> {
 	addPressed(key: string): void {
 		this.setState({ pressedButtons: [...this.state.pressedButtons, key] });
 		const btn = this.state.buttonProperties.flat().find(b => b.code === key);
-		if (!btn || !btn.audio || btn.active || !this.audio.sounds.has(btn.audio))
+		if (!btn || !btn.audio || !this.audio.sounds.has(btn.audio))
 			return;
+		if (btn.active) {
+			return this.audio.playing.get(btn.audio).stop();
+		}
 		this.updateButtonProperties(btn.position, { active: true });
 		this.audio.playSound(btn.audio, btn.volume, () => this.updateButtonProperties(btn.position, { active: false }));
 	}

--- a/src/components/PadButton.tsx
+++ b/src/components/PadButton.tsx
@@ -16,7 +16,8 @@ class PadButton extends React.Component<PadButtonProps> {
 
 	render(): React.ReactNode {
 		const style = {
-			backgroundColor: this.props.active ? this.props.activeColor : this.props.idleColor
+			backgroundColor: this.props.idleColor,
+			'--activeColor': this.props.activeColor
 		};
 		let label;
 		if (this.props.label)
@@ -25,7 +26,7 @@ class PadButton extends React.Component<PadButtonProps> {
 			label = this.props.code;
 		return (
 			<div
-				className={'pad-button ' + this.props.className}
+				className={'pad-button ' + (this.props.active ? 'active ' : '') + this.props.className}
 				style={style}
 				onMouseDown={() => this.props.select(this.props.position)}
 			>

--- a/src/components/PadButton.tsx
+++ b/src/components/PadButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import '../style/PadButton.sass';
 import PadButtonProps from '../types/PadButtonProps';
+import ProgressIndicator from './ProgressIndicator';
 
 /**
  * A button in a Pad.
@@ -24,6 +25,10 @@ class PadButton extends React.Component<PadButtonProps> {
 			label = this.props.label;
 		if (this.props.alt)
 			label = this.props.code;
+		const buffer = this.props.audioManager.sounds.get(this.props.audio);
+		let duration;
+		if (buffer)
+			duration = buffer.duration;
 		return (
 			<div
 				className={'pad-button ' + (this.props.active ? 'active ' : '') + this.props.className}
@@ -31,6 +36,7 @@ class PadButton extends React.Component<PadButtonProps> {
 				onMouseDown={() => this.props.select(this.props.position)}
 			>
 				{<div className='pad-button-label'>{label}</div>}
+				<ProgressIndicator duration={duration} active={this.props.active} />
 			</div>
 		);
 	}

--- a/src/components/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import '../style/ProgressIndicator.sass';
+
+/**
+ * Indicator of the progress of a PadButton's audio.
+ */
+function ProgressIndicator(props: { duration: number, active: boolean }): React.ReactElement {
+	const style = { animation: `progressing ${props.duration}s linear` } as React.CSSProperties;
+	return (
+		<div className='progress-indicator'>
+			{props.active && <div className='progress-indicator-inner' style={style}></div>}
+		</div>
+	);
+}
+
+export default ProgressIndicator;

--- a/src/style/PadButton.sass
+++ b/src/style/PadButton.sass
@@ -18,9 +18,14 @@
 	&.failing
 		animation: failing 2s steps(1, start) infinite normal
 	&.selected
-		// animation: none
 		border: 4px solid aqua
+	&.active
+		animation: active 1.5s steps(1, start) infinite normal
 
 @keyframes failing
 	50%
 		border: 4px solid red
+
+@keyframes active
+	50%
+		background: var(--activeColor)

--- a/src/style/PadButton.sass
+++ b/src/style/PadButton.sass
@@ -1,4 +1,5 @@
 .pad-button
+	position: relative
 	align-items: center
 	justify-content: center
 	display: inline-flex

--- a/src/style/ProgressIndicator.sass
+++ b/src/style/ProgressIndicator.sass
@@ -1,0 +1,18 @@
+.progress-indicator
+	position: absolute
+	bottom: 15px
+	width: 80%
+	height: 3px
+	border-radius: 10em
+	background: #FFFFFF90
+	overflow: hidden
+	.progress-indicator-inner
+		position: absolute
+		height: 100%
+		background: #FFFFFF
+
+@keyframes progressing
+	0%
+		width: 0
+	100%
+		width: 100%

--- a/src/types/ButtonProperties.ts
+++ b/src/types/ButtonProperties.ts
@@ -3,6 +3,10 @@
  */
 interface ButtonProperties {
 	/**
+	 * Whether the button is currently playing a sound.
+	 */
+	active: boolean;
+	/**
 	 * The color to display when the button component is active.
 	 */
 	activeColor: string;

--- a/src/types/PadButtonProps.ts
+++ b/src/types/PadButtonProps.ts
@@ -1,9 +1,14 @@
+import AudioManager from '../audio/AudioManager';
 import ButtonProperties from './ButtonProperties';
 
 /**
  * Props of a PadButton component.
  */
 interface PadButtonProps extends ButtonProperties {
+	/**
+	 * The AudioManager of the Pad.
+	 */
+	audioManager: AudioManager,
 	/**
 	 * Whether the AltRight key is pressed, which displays the code of the PadButton.
 	 */

--- a/src/types/PadButtonProps.ts
+++ b/src/types/PadButtonProps.ts
@@ -5,10 +5,6 @@ import ButtonProperties from './ButtonProperties';
  */
 interface PadButtonProps extends ButtonProperties {
 	/**
-	 * Whether the PadButton is currently being pressed.
-	 */
-	active: boolean;
-	/**
 	 * Whether the AltRight key is pressed, which displays the code of the PadButton.
 	 */
 	alt: boolean;


### PR DESCRIPTION
**Changes of this PR**
- A button is now active while its audio is being played, not while it is being pressed/clicked.
This is temporary, as buttons will later have different types. This will aply to only certain types of buttons, currently being the default one.
- This type of button will also have a sound progress indicator.