### PR TITLE
feat(Pad): ignore keypresses when input is focused

### DIFF
--- a/src/components/ButtonConfigurator.tsx
+++ b/src/components/ButtonConfigurator.tsx
@@ -91,7 +91,7 @@ class ButtonConfigurator extends React.Component<ButtonConfiguratorProps> {
 					<label htmlFor='idleColor'>Idle color</label>
 				</div>
 				<div className='button-configurator-subtitle'>Label</div>
-				<input type='text' ref={this.#refs.label} name='label' onChange={this.onChange} />
+				<input type='text' ref={this.#refs.label} name='label' onChange={this.onChange} onFocus={this.props.setFreezed.bind(this, true)} onBlur={this.props.setFreezed.bind(this, false)} />
 				<div className='button-configurator-subtitle'>Audio</div>
 				<input type='file' ref={this.#refs.audio} name='audio' accept='audio/*' onChange={this.onChange} />
 				<input type='range' min='0' max='100' defaultValue='50' ref={this.#refs.volume} name='volume' onChange={this.onChange} />

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -51,10 +51,10 @@ class Pad extends React.Component<PadProps, PadState> {
 
 	componentDidMount(): void {
 		window.addEventListener('keydown', (e: KeyboardEvent) => {
-			if (e.shiftKey)
-				return;
 			if (e.code === 'Escape')
-				this.setState({ selectedButton: undefined });
+				this.setState({ selectedButton: undefined, freezeKeys: false });
+			if (e.shiftKey || this.state.freezeKeys)
+				return;
 			if (!this.state.pressedButtons.includes(e.code))
 				this.addPressed(e.code);
 		});
@@ -169,6 +169,7 @@ class Pad extends React.Component<PadProps, PadState> {
 					...btn,
 					audioManager: this.audio,
 					alt: this.state.pressedButtons.includes('AltRight'),
+					freezed: this.state.freezeKeys,
 					select: (coos: number[]) => this.selectButton(coos)
 				};
 				const isSelected = this.state.selectedButton && this.state.selectedButton[0] === i && this.state.selectedButton[1] === j;

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -42,6 +42,7 @@ class Pad extends React.Component<PadProps, PadState> {
 		} else
 			properties = this.generateDefaultButtons();
 		this.state = {
+			freezeKeys: false,
 			pressedButtons: [],
 			buttonProperties: properties
 		};

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -42,7 +42,7 @@ class Pad extends React.Component<PadProps, PadState> {
 		} else
 			properties = this.generateDefaultButtons();
 		this.state = {
-			freezeKeys: false,
+			freezed: false,
 			pressedButtons: [],
 			buttonProperties: properties
 		};
@@ -52,8 +52,8 @@ class Pad extends React.Component<PadProps, PadState> {
 	componentDidMount(): void {
 		window.addEventListener('keydown', (e: KeyboardEvent) => {
 			if (e.code === 'Escape')
-				this.setState({ selectedButton: undefined, freezeKeys: false });
-			if (e.shiftKey || this.state.freezeKeys)
+				this.setState({ selectedButton: undefined, freezed: false });
+			if (e.shiftKey || this.state.freezed)
 				return;
 			if (!this.state.pressedButtons.includes(e.code))
 				this.addPressed(e.code);
@@ -110,7 +110,7 @@ class Pad extends React.Component<PadProps, PadState> {
 	}
 
 	setFreezed(freezed: boolean): void {
-		this.setState({ freezeKeys: freezed });
+		this.setState({ freezed: freezed });
 	}
 
 	updateButtonProperties(coos: number[], properties: Partial<ButtonProperties>): void {
@@ -169,7 +169,7 @@ class Pad extends React.Component<PadProps, PadState> {
 					...btn,
 					audioManager: this.audio,
 					alt: this.state.pressedButtons.includes('AltRight'),
-					freezed: this.state.freezeKeys,
+					freezed: this.state.freezed,
 					select: (coos: number[]) => this.selectButton(coos)
 				};
 				const isSelected = this.state.selectedButton && this.state.selectedButton[0] === i && this.state.selectedButton[1] === j;

--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -109,6 +109,10 @@ class Pad extends React.Component<PadProps, PadState> {
 		this.setState({ selectedButton: coos });
 	}
 
+	setFreezed(freezed: boolean): void {
+		this.setState({ freezeKeys: freezed });
+	}
+
 	updateButtonProperties(coos: number[], properties: Partial<ButtonProperties>): void {
 		const updated = { ...this.state.buttonProperties[coos[0]][coos[1]], ...properties };
 		if ('audio' in properties)
@@ -194,6 +198,7 @@ class Pad extends React.Component<PadProps, PadState> {
 				<ButtonConfigurator
 					updater={updater}
 					button={button}
+					setFreezed={(freezed: boolean) => this.setFreezed(freezed)}
 				/>
 			</>
 		);

--- a/src/components/PadButton.tsx
+++ b/src/components/PadButton.tsx
@@ -11,7 +11,7 @@ class PadButton extends React.Component<PadButtonProps> {
 
 	componentDidMount(): void {
 		window.addEventListener('keydown', (e: KeyboardEvent) => {
-			if (e.shiftKey && e.code === this.props.code)
+			if (!this.props.freezed && e.shiftKey && e.code === this.props.code)
 				this.props.select(this.props.position);
 		});
 	}

--- a/src/types/ButtonConfiguratorProps.ts
+++ b/src/types/ButtonConfiguratorProps.ts
@@ -6,6 +6,10 @@ interface ButtonConfiguratorProps {
 	 */
 	button?: ButtonProperties;
 	/**
+	 * Function to set whether the Pad's key events must be ignored.
+	 */
+	setFreezed: (freezed: boolean) => void;
+	/**
 	 * A function to call with the updated properties of the button. 
 	 */
 	updater?: (p: Partial<ButtonProperties>) => void;

--- a/src/types/PadButtonProps.ts
+++ b/src/types/PadButtonProps.ts
@@ -18,6 +18,10 @@ interface PadButtonProps extends ButtonProperties {
 	 */
 	className?: string;
 	/**
+	 * Whether to ignore key events.
+	 */
+	freezed: boolean;
+	/**
 	 * The function to call to select this button in the configurator.
 	 */
 	select: (coos: number[]) => void;

--- a/src/types/PadState.ts
+++ b/src/types/PadState.ts
@@ -9,6 +9,10 @@ interface PadState {
 	 */
 	buttonProperties: ButtonProperties[][];
 	/**
+	 * Whether to ignore keyboard events (except Escape), for example when a text input is focused.
+	 */
+	freezeKeys: boolean;
+	/**
 	 * Array of pressed keys' codes.
 	 */
 	pressedButtons: string[];

--- a/src/types/PadState.ts
+++ b/src/types/PadState.ts
@@ -11,7 +11,7 @@ interface PadState {
 	/**
 	 * Whether to ignore keyboard events (except Escape), for example when a text input is focused.
 	 */
-	freezeKeys: boolean;
+	freezed: boolean;
 	/**
 	 * Array of pressed keys' codes.
 	 */


### PR DESCRIPTION
**Changes of this PR**
When a text input (e.g. button label editor) is focused, keypresses (except for Escape) will be ignored to avoid unwanted mess.